### PR TITLE
Fix circular import error causing Render deployment failure

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -5,34 +5,11 @@ from api.routes.v2 import activities as v2_activities
 from api.oauth import github 
 from api.database import engine, Base
 from api.models import tokens
-from api.auth import get_api_key_tier, APIKeyTier
+from api.rate_limiting import limiter
 
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
+from slowapi import _rate_limit_exceeded_handler
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.errors import RateLimitExceeded
-
-# Custom key function for tiered rate limiting
-def get_tiered_rate_limit_key(request: Request):
-    api_key = request.headers.get("X-API-Key")
-    if api_key:
-        tier = get_api_key_tier(api_key)
-        return f"{api_key}:{tier.value}"
-    return get_remote_address(request)
-
-def get_rate_limit_for_request(request: Request) -> str:
-    api_key = request.headers.get("X-API-Key")
-    if api_key:
-        tier = get_api_key_tier(api_key)
-        if tier == APIKeyTier.ADMIN:
-            return "10000/hour"  # Admin: 10k requests/hour
-        elif tier == APIKeyTier.PREMIUM:
-            return "5000/hour"   # Premium: 5k requests/hour
-        else:
-            return "1000/hour"   # Basic: 1k requests/hour
-    return "100/hour"  # No API key: 100 requests/hour
-
-limiter = Limiter(key_func=get_tiered_rate_limit_key)
 
 app = FastAPI(title="Silvanus API")
 

--- a/api/rate_limiting.py
+++ b/api/rate_limiting.py
@@ -1,0 +1,26 @@
+from fastapi import Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from api.auth import get_api_key_tier, APIKeyTier
+
+# Custom key function for tiered rate limiting
+def get_tiered_rate_limit_key(request: Request):
+    api_key = request.headers.get("X-API-Key")
+    if api_key:
+        tier = get_api_key_tier(api_key)
+        return f"{api_key}:{tier.value}"
+    return get_remote_address(request)
+
+def get_rate_limit_for_request(request: Request) -> str:
+    api_key = request.headers.get("X-API-Key")
+    if api_key:
+        tier = get_api_key_tier(api_key)
+        if tier == APIKeyTier.ADMIN:
+            return "10000/hour"  # Admin: 10k requests/hour
+        elif tier == APIKeyTier.PREMIUM:
+            return "5000/hour"   # Premium: 5k requests/hour
+        else:
+            return "1000/hour"   # Basic: 1k requests/hour
+    return "100/hour"  # No API key: 100 requests/hour
+
+limiter = Limiter(key_func=get_tiered_rate_limit_key)

--- a/api/routes/v2/activities.py
+++ b/api/routes/v2/activities.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends, Request
 from pydantic import BaseModel, validator, Field
 from api.auth import get_api_key_with_tier, APIKeyTier
-from api.main import limiter, get_rate_limit_for_request
+from api.rate_limiting import limiter, get_rate_limit_for_request
 from web3 import Web3
 from dotenv import load_dotenv
 import os


### PR DESCRIPTION

# Fix circular import error causing Render deployment failure

## Summary

This PR resolves a critical circular import error that was preventing the Silvanus API from deploying on Render. The error occurred because `api/main.py` was importing from `api/routes/v2/activities.py` while `api/routes/v2/activities.py` was importing limiter and rate limiting functions from `api/main.py`, creating a circular dependency.

**Key Changes:**
- Created new `api/rate_limiting.py` module to house the limiter instance and rate limiting functions
- Updated `api/main.py` to import from the new rate_limiting module instead of defining functions inline
- Updated `api/routes/v2/activities.py` to import from the new rate_limiting module instead of api.main

**Root Cause:** The circular import was introduced when API versioning was added (v1/v2 endpoints), requiring `api/main.py` to import from `api/routes/v2/activities.py` while the v2 activities module needed access to the limiter instance defined in main.

## Review & Testing Checklist for Human

- [ ] **Verify rate limiting functionality works correctly** - Test both v1 and v2 endpoints with different API key tiers to ensure rate limits are properly applied
- [ ] **Test API endpoints function correctly** - Submit test activities to both `/v1/activities/submit` and `/v2/activities/submit` endpoints  
- [ ] **Confirm Render deployment succeeds** - Merge this PR and verify the Render build completes successfully without circular import errors
- [ ] **Test production API health** - After deployment, verify the `/healthz` endpoint responds correctly and the service is operational

**Recommended Test Plan:**
1. Test imports work locally: `python -c "from api.main import app; from api.routes.v2.activities import router"`
2. Run API locally and test rate limiting with different API keys
3. Submit test activities to verify blockchain integration still works
4. Monitor Render deployment logs for successful startup

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    main["api/main.py<br/>FastAPI app setup"]:::major-edit
    ratelimiting["api/rate_limiting.py<br/>Limiter & rate functions"]:::major-edit
    v2activities["api/routes/v2/activities.py<br/>V2 API endpoints"]:::minor-edit
    v1activities["api/routes/v1/activities.py<br/>V1 API endpoints"]:::context
    auth["api/auth.py<br/>API key authentication"]:::context
    
    main -->|"imports limiter"| ratelimiting
    v2activities -->|"imports limiter,<br/>get_rate_limit_for_request"| ratelimiting
    v1activities -->|"imports get_api_key"| auth
    v2activities -->|"imports get_api_key_with_tier,<br/>APIKeyTier"| auth
    ratelimiting -->|"imports get_api_key_tier,<br/>APIKeyTier"| auth
    main -->|"registers router"| v2activities
    main -->|"registers router"| v1activities
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The circular import error was preventing the Render deployment from completing with "ImportError: cannot import name 'limiter' from partially initialized module 'api.main'"
- Local testing confirmed imports work correctly, but production environment testing is critical
- This fix maintains all existing functionality while resolving the import cycle
- **Session Info:** Created by Devin AI for blizzard25 (@blizzard25) - [Link to Devin run](https://app.devin.ai/sessions/23e6363ad50a4d9d8f817ff8013b46b7)
