### PR TITLE
Fix v2 endpoint rate limiting syntax error causing 500 errors

### DIFF
--- a/api/routes/v2/activities.py
+++ b/api/routes/v2/activities.py
@@ -92,13 +92,12 @@ class RewardResponse(BaseModel):
     status: str
 
 @router.post("/submit", response_model=RewardResponse)
+@limiter.limit(lambda request: get_rate_limit_for_request(request))
 async def submit_activity(
     request: Request,
     activity: ActivitySubmission,
     auth_info: dict = Depends(get_api_key_with_tier)
 ):
-    rate_limit = get_rate_limit_for_request(request)
-    await limiter.limit(rate_limit)(request)
     
     try:
         print(f"[V2 Submit] API Tier: {auth_info['tier'].value}")


### PR DESCRIPTION

# Fix v2 endpoint rate limiting syntax error causing 500 errors

## Summary

This PR fixes a critical production issue where the v2 activities endpoint was returning 500 Internal Server Errors due to incorrect rate limiting syntax. The error `AttributeError: 'Request' object has no attribute '__name__'` was caused by incorrectly calling the slowapi limiter directly inside the function body instead of using it as a decorator.

**Key Change:**
- **Before:** `await limiter.limit(rate_limit)(request)` inside function body
- **After:** `@limiter.limit(lambda request: get_rate_limit_for_request(request))` as decorator

This resolves the production deployment issue where v2 endpoint requests were failing with 500 errors, while maintaining the tiered rate limiting functionality (basic: 1000/hour, premium: 5000/hour, admin: 10000/hour).

## Review & Testing Checklist for Human

⚠️ **CRITICAL**: This fixes a live production issue affecting the v2 endpoint. Thorough testing is essential.

- [ ] **Test v2 endpoint functionality** - Verify `/v2/activities/submit` no longer returns 500 errors
- [ ] **Verify tiered rate limiting works** - Test different API key tiers (basic, premium, admin) have correct limits
- [ ] **Test authentication edge cases** - Verify proper handling of missing/invalid API keys
- [ ] **Confirm lambda evaluation** - Ensure the lambda function properly evaluates rate limits per request
- [ ] **Run enhanced test script** - Execute `python test_rewards_api.py` to verify all v2 tests pass

**Recommended test plan:**
1. Deploy this fix to Render and monitor logs
2. Test v2 endpoint with curl/Postman using different API keys
3. Verify rate limiting enforcement by making multiple rapid requests
4. Run the comprehensive test script to ensure full functionality

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    V2Route["api/routes/v2/activities.py<br/>submit_activity()"]:::major-edit
    RateLimiting["api/rate_limiting.py<br/>get_rate_limit_for_request()"]:::context
    Auth["api/auth.py<br/>get_api_key_with_tier()"]:::context
    SlowAPI["slowapi.Limiter<br/>decorator"]:::context
    
    V2Route -->|"@limiter.limit(lambda...)"| SlowAPI
    V2Route -->|"calls for rate limit"| RateLimiting
    V2Route -->|"depends on"| Auth
    RateLimiting -->|"determines tier limits"| Auth
    
    Error["500 Internal Server Error<br/>BEFORE"]:::context
    Fixed["Working v2 endpoint<br/>AFTER"]:::major-edit
    
    V2Route -->|"caused"| Error
    V2Route -->|"now produces"| Fixed
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This fix directly addresses the production error logs provided showing `AttributeError: 'Request' object has no attribute '__name__'`
- The slowapi library expects decorators, not direct function calls with request objects
- The lambda approach ensures rate limits are evaluated per request while maintaining the tiered API key functionality
- All other v1 and legacy endpoints continue to work as expected
- This change only affects the v2 endpoint implementation

**Link to Devin run**: https://app.devin.ai/sessions/23e6363ad50a4d9d8f817ff8013b46b7    
**Requested by**: Evan (@blizzard25)
