### PR TITLE
Fix v2 endpoint wallet address checksum validation

### DIFF
--- a/api/routes/v2/activities.py
+++ b/api/routes/v2/activities.py
@@ -60,7 +60,9 @@ class ActivitySubmission(BaseModel):
         if not re.match(r'^[0-9a-f]{40}$', address):
             raise ValueError('Invalid Ethereum wallet address format')
         
-        return '0x' + address if not v.startswith('0x') else v.lower()
+        from web3 import Web3
+        normalized_address = '0x' + address if not v.startswith('0x') else v.lower()
+        return Web3.to_checksum_address(normalized_address)
     
     @validator('activity_type')
     def validate_activity_type(cls, v):


### PR DESCRIPTION

# Fix v2 endpoint wallet address checksum validation

## Summary
Fixes the remaining 500 Internal Server Error on the v2 activities endpoint caused by Web3.py requiring checksum addresses. The previous PR #7 resolved the lambda function TypeError, but revealed a second issue where the wallet address validator was returning lowercase addresses that Web3.py rejects.

**Root Cause:** The `validate_wallet_address` function in the v2 endpoint was returning `v.lower()`, but Web3.py's smart contract interaction requires checksum addresses.

**Solution:** Updated the validator to use `Web3.to_checksum_address()` to convert validated addresses to proper checksum format while maintaining all existing validation logic.

## Review & Testing Checklist for Human
- [ ] **Test v2 endpoint with valid wallet addresses** - Verify it now returns 200 instead of 500
- [ ] **Test v2 endpoint with invalid wallet addresses** - Ensure validation still rejects malformed addresses with 422
- [ ] **Regression test v1 and legacy endpoints** - Confirm they still work correctly (should be unaffected)
- [ ] **End-to-end test**: Use the `python/test_rewards_api.py` script to verify all endpoints work as expected

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    TestScript["python/test_rewards_api.py"]
    V2Activities["api/routes/v2/activities.py"]:::major-edit
    V1Activities["api/routes/v1/activities.py"]:::context
    LegacyActivities["api/routes/activities.py"]:::context
    Web3Lib["Web3.py Library"]:::context
    
    TestScript --> V2Activities
    TestScript --> V1Activities
    TestScript --> LegacyActivities
    V2Activities --> Web3Lib
    
    V2Activities --> ValidationFix["validate_wallet_address()<br/>+ Web3.to_checksum_address()"]:::major-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- This is a follow-up to PR #7 which fixed the lambda function error
- Only affects the v2 endpoint - v1 and legacy endpoints use different validation logic
- The fix maintains all existing validation (format checks, length validation) while ensuring Web3.py compatibility
- **Session Link**: https://app.devin.ai/sessions/23e6363ad50a4d9d8f817ff8013b46b7
- **Requested by**: @blizzard25
