### PR TITLE
Update test script to remove tier-based rate limiting tests

### DIFF
--- a/python/test_rewards_api.py
+++ b/python/test_rewards_api.py
@@ -12,9 +12,7 @@ load_dotenv()
 BASE_URL = "https://silvanus-a4nt.onrender.com"
 
 API_KEYS = {
-    "basic": "12062569evan1206",  # Basic tier (1000/hour)
-    "premium": "premium_key_test",  # Premium tier (5000/hour) - placeholder
-    "admin": "admin_key_test",  # Admin tier (10000/hour) - placeholder
+    "valid": "12062569evan1206",  # Valid API key (1000/hour fixed rate limit)
     "invalid": "invalid_key_123"  # Invalid key for testing
 }
 
@@ -45,7 +43,7 @@ def test_health_endpoint():
 def test_activity_types_endpoint():
     """Test activity types endpoint"""
     print("\n=== ACTIVITY TYPES TEST ===")
-    response = make_request("/activities/types", api_key=API_KEYS["basic"])
+    response = make_request("/activities/types", api_key=API_KEYS["valid"])
     print(f"→ Activity Types: {response.status_code}")
     if response.status_code == 200:
         try:
@@ -71,7 +69,7 @@ def test_v1_endpoint():
         }
     }
     
-    response = make_request("/v1/activities/submit", activity_payload, API_KEYS["basic"], "POST")
+    response = make_request("/v1/activities/submit", activity_payload, API_KEYS["valid"], "POST")
     print(f"→ V1 Submit Activity: {response.status_code}")
     if response.status_code != 200:
         print(f"   Error: {response.text}")
@@ -101,7 +99,7 @@ def test_v2_endpoint():
         }
     }
     
-    response = make_request("/v2/activities/submit", activity_payload, API_KEYS["basic"], "POST")
+    response = make_request("/v2/activities/submit", activity_payload, API_KEYS["valid"], "POST")
     print(f"→ V2 Submit Activity: {response.status_code}")
     if response.status_code != 200:
         print(f"   Error: {response.text}")
@@ -130,7 +128,7 @@ def test_legacy_endpoint():
         }
     }
     
-    response = make_request("/activities/submit", activity_payload, API_KEYS["basic"], "POST")
+    response = make_request("/activities/submit", activity_payload, API_KEYS["valid"], "POST")
     print(f"→ Legacy Submit Activity: {response.status_code}")
     if response.status_code != 200:
         print(f"   Error: {response.text}")
@@ -153,7 +151,7 @@ def test_input_validation():
         "activity_type": "solar_export",
         "value": 5.0
     }
-    response = make_request("/v2/activities/submit", invalid_payload, API_KEYS["basic"], "POST")
+    response = make_request("/v2/activities/submit", invalid_payload, API_KEYS["valid"], "POST")
     print(f"   Invalid wallet: {response.status_code} (expected 422)")
     
     print("→ Testing invalid activity type...")
@@ -162,7 +160,7 @@ def test_input_validation():
         "activity_type": "invalid_activity",
         "value": 5.0
     }
-    response = make_request("/v2/activities/submit", invalid_payload, API_KEYS["basic"], "POST")
+    response = make_request("/v2/activities/submit", invalid_payload, API_KEYS["valid"], "POST")
     print(f"   Invalid activity type: {response.status_code} (expected 422)")
     
     print("→ Testing value out of range...")
@@ -171,11 +169,11 @@ def test_input_validation():
         "activity_type": "solar_export",
         "value": 15000.0  # Exceeds 10000 limit
     }
-    response = make_request("/v2/activities/submit", invalid_payload, API_KEYS["basic"], "POST")
+    response = make_request("/v2/activities/submit", invalid_payload, API_KEYS["valid"], "POST")
     print(f"   Value too high: {response.status_code} (expected 422)")
 
 def test_rate_limiting():
-    """Test rate limiting with different API key tiers"""
+    """Test rate limiting and authentication"""
     print("\n=== RATE LIMITING TESTS ===")
     
     print("→ Testing no API key rate limit...")
@@ -194,13 +192,13 @@ def test_rate_limiting():
     }, API_KEYS["invalid"], "POST")
     print(f"   Invalid API key: {response.status_code}")
     
-    print("→ Testing basic tier value limit...")
+    print("→ Testing valid API key with normal value...")
     response = make_request("/v2/activities/submit", {
         "wallet_address": owner_wallet,
         "activity_type": "solar_export",
-        "value": 150.0  # Exceeds basic tier 100 kWh limit
-    }, API_KEYS["basic"], "POST")
-    print(f"   Basic tier large value: {response.status_code} (expected 403)")
+        "value": 150.0  # Normal value within 10000 limit
+    }, API_KEYS["valid"], "POST")
+    print(f"   Valid API key normal value: {response.status_code} (expected 200)")
 
 def test_api_authentication():
     """Test API authentication scenarios"""


### PR DESCRIPTION

# Update test script to remove tier-based rate limiting tests

## Summary
This PR updates the test script `python/test_rewards_api.py` to remove outdated tier-based rate limiting tests that were causing confusion after the tier system (basic/premium/admin) was removed from the API. The main issue was that the "basic tier large value" test expected a 403 error for large values but was getting 200, which was incorrect since the tier system no longer exists.

**Key Changes:**
- Removed API key tiers (basic/premium/admin) and replaced with simple valid/invalid keys
- Replaced problematic "basic tier value limit" test that expected 403 for large values
- Added proper "valid API key with normal value" test expecting 200
- Kept existing large value validation test (15000.0 kWh expecting 422) which works correctly
- All 5/5 tests now pass with correct expectations

## Review & Testing Checklist for Human
- [ ] **Verify v2 endpoint large value validation**: Test that `/v2/activities/submit` properly rejects values > 10000 kWh with 422 status code
- [ ] **Confirm tier system removal is complete**: Check that no tier-based logic remains in the codebase (basic/premium/admin references)
- [ ] **Test authentication flows**: Verify that valid API keys return 200 and invalid/missing keys return 403
- [ ] **Run updated test script**: Execute `python python/test_rewards_api.py` to confirm all tests pass with correct expectations

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    TestScript["python/test_rewards_api.py<br/>Test Script"]:::major-edit
    V2Endpoint["api/routes/v2/activities.py<br/>V2 Activities Endpoint"]:::context
    RateLimit["api/rate_limiting.py<br/>Rate Limiting Config"]:::context
    
    TestScript -->|"Tests authentication"| V2Endpoint
    TestScript -->|"Tests rate limiting"| RateLimit
    V2Endpoint -->|"Uses fixed rate limit"| RateLimit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- The v2 endpoint already has proper validation via Pydantic Field (`le=10000.0`) and custom validator - no endpoint logic changes needed
- This resolves the confusion where tests expected 403 for large values but got 200, which was correct behavior after tier removal
- All core functionality (authentication, rate limiting, input validation) continues to work as expected


**Session Info**: Requested by Evan (@blizzard25)  
**Link to Devin run**: https://app.devin.ai/sessions/23e6363ad50a4d9d8f817ff8013b46b7
