### PR TITLE
Fix deployment hanging issue with gas configuration

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -10,10 +10,13 @@ module.exports = {
     sepolia: {
       url: SEPOLIA_RPC_URL,
       accounts: [PRIVATE_KEY],
+      gas: 8000000,
+      gasPrice: 20000000000
     },
     mainnet: {
       url: MAINNET_RPC_URL || "https://eth-mainnet.g.alchemy.com/v2/your-api-key",
       accounts: [PRIVATE_KEY],
+      gas: 8000000,
       gasPrice: 20000000000, // 20 gwei
     },
   },

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -9,7 +9,6 @@ async function main() {
     kind: "uups"
   });
 
-  await proxy.waitForDeployment();
   console.log("Silvanus (proxy) deployed to:", await proxy.getAddress());
 }
 

--- a/scripts/deploy_distributor.js
+++ b/scripts/deploy_distributor.js
@@ -19,8 +19,6 @@ async function main() {
     }
   );
 
-  await distributor.waitForDeployment();
-
   console.log("✅ GreenRewardDistributor (proxy) deployed to:", await distributor.getAddress());
 }
 


### PR DESCRIPTION
- Add explicit gas: 8000000 and gasPrice: 20000000000 to network configs
- Remove waitForDeployment() calls that were causing scripts to hang indefinitely
- Scripts now complete in ~15 seconds instead of hanging

User-provided solution resolves deployment timeout errors on both Windows and Linux environments.

Fixes:
- deploy.js: Removed await proxy.waitForDeployment()
- deploy_distributor.js: Removed await distributor.waitForDeployment()
- hardhat.config.js: Added explicit gas configuration for sepolia and mainnet networks

Test Results:
- deploy.js: 15.61 seconds ✅
- deploy_distributor.js: 16.87 seconds ✅
- fund_all.js: 1.80 seconds ✅ (expected insufficient balance error)