### PR TITLE
Fix Silvanus token deployment to mint 100M initial tokens

### DIFF
--- a/scripts/deploy_all.js
+++ b/scripts/deploy_all.js
@@ -35,7 +35,7 @@ async function main() {
   // Step 1: Deploy Silvanus Token
   console.log("\n🪙 Step 1: Deploying Silvanus Token...");
   const Silvanus = await ethers.getContractFactory("Silvanus");
-  const silvanus = await upgrades.deployProxy(Silvanus, [deployer.address], {
+  const silvanus = await upgrades.deployProxy(Silvanus, [ethers.parseEther("100000000")], {
     initializer: "initialize",
     kind: "uups",
   });


### PR DESCRIPTION
# Fix Silvanus token deployment to mint 100M initial tokens

## Summary

Fixed a critical bug in `scripts/deploy_all.js` where the Silvanus token was not minting the correct initial supply. The issue was on line 38 where `deployer.address` (an Ethereum address) was being passed to the contract's `initialize` function instead of the initial supply amount.

**Root cause**: The Silvanus contract's `initialize` function expects a `uint256 initialSupply` parameter, but `deploy_all.js` was incorrectly passing `deployer.address` instead.

**Fix**: Changed the deployment parameter from `[deployer.address]` to `[ethers.parseEther("100000000")]` to properly mint 100M tokens, following the same pattern used in the standalone `deploy.js` script.

## Review & Testing Checklist for Human

- [ ] **Verify 100M tokens is the correct intended initial supply** - confirm this matches business requirements
- [ ] **Test the deployment script end-to-end in a test environment** - run the full `deploy_all.js` script on testnet to ensure it works correctly
- [ ] **Verify token allocation math still adds up** - check that the downstream distribution logic in lines 86-99 still works with 100M initial supply
- [ ] **Compare with standalone deploy.js behavior** - ensure both scripts now behave consistently for token creation
- [ ] **Test on testnet before mainnet** - deploy to Sepolia first to catch any unforeseen issues

## Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Deploy["scripts/deploy_all.js<br/>(Line 38 - Fixed)"]:::major-edit
    Silvanus["contracts/Silvanus.sol<br/>(initialize function)"]:::context
    DeployStandalone["scripts/deploy.js<br/>(Reference pattern)"]:::context
    
    Deploy -->|"upgrades.deployProxy(Silvanus,<br/>[ethers.parseEther('100000000')])"| Silvanus
    DeployStandalone -->|"Same pattern<br/>(for reference)"| Silvanus
    
    Silvanus -->|"_mint(msg.sender, initialSupply)"| TokenMint["100M SVN tokens<br/>minted to deployer"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

## Notes

- This fix addresses the "arbitrary number" of tokens being minted that the user reported
- The change is isolated to one parameter but affects critical token economics
- **Important**: This change has NOT been tested end-to-end due to Hardhat config issues in the dev environment
- The fix follows the established pattern in `deploy.js` which properly mints 100M tokens
- Requested by @blizzard25 
- Link to Devin run: https://app.devin.ai/sessions/1f84d8c9ccd6444f85e98749ed998ea6