### PR TITLE
Fix mainnet deployment: pass initial supply instead of deployer address

### DIFF
--- a/scripts/deploy_all.js
+++ b/scripts/deploy_all.js
@@ -35,7 +35,7 @@ async function main() {
   // Step 1: Deploy Silvanus Token
   console.log("\n🪙 Step 1: Deploying Silvanus Token...");
   const Silvanus = await ethers.getContractFactory("Silvanus");
-  const silvanus = await upgrades.deployProxy(Silvanus, [deployer.address], {
+  const silvanus = await upgrades.deployProxy(Silvanus, [ethers.parseEther("100000000")], {
     initializer: "initialize",
     kind: "uups",
   });


### PR DESCRIPTION
# Fix mainnet deployment: pass initial supply instead of deployer address

## Summary

Fixed a critical bug in `scripts/deploy_all.js` where mainnet deployment was failing with "invalid address" error. The root cause was passing `deployer.address` (an Ethereum address) to the Silvanus contract's `initialize` function, which expects a `uint256 initialSupply` parameter.

**Key change**: Line 38 now correctly passes `ethers.parseEther("100000000")` to mint 100M tokens instead of passing the deployer's address.

This fix resolves the mainnet deployment error where the transaction failed during proxy creation due to parameter type mismatch.

## Review & Testing Checklist for Human

- [ ] **Verify 100M tokens is the correct intended initial supply** - confirm this matches your business requirements and tokenomics
- [ ] **Test the complete deployment script on testnet first** - run `npx hardhat run scripts/deploy_all.js --network sepolia` to ensure it works end-to-end
- [ ] **Verify token allocation math still works** - check that the distribution logic in lines 86-99 correctly allocates percentages with 100M total supply
- [ ] **Investigate why previous fix was reverted** - this appears to be the same bug from PR #25, need to understand why it got reverted to prevent regression

## Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    DeployAll["scripts/deploy_all.js<br/>(Line 38 - Fixed)"]:::major-edit
    Silvanus["contracts/Silvanus.sol<br/>(initialize function)"]:::context
    HardhatConfig["hardhat.config.js<br/>(mainnet config)"]:::context
    
    DeployAll -->|"upgrades.deployProxy(Silvanus,<br/>[ethers.parseEther('100000000')])"| Silvanus
    HardhatConfig -->|"mainnet network settings"| DeployAll
    
    Silvanus -->|"_mint(msg.sender, initialSupply)"| TokenMint["100M SVN tokens<br/>minted to deployer"]:::context
    TokenMint -->|"transfer() calls"| Allocations["Token allocations:<br/>- Treasury: 12.5M<br/>- Marketing: 10M<br/>- Partnerships: 7.5M<br/>- Liquidity: 9M<br/>- Rewards: 40M<br/>- Presale: 21M"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

## Notes

- This is the same bug that was apparently fixed in PR #25 but somehow got reverted in the main branch
- The error occurred because ethers.js tried to interpret the address parameter as a transaction field, causing "invalid value for value.to" error
- The fix follows the correct pattern shown in the standalone `deploy.js` script
- **Critical**: This change has not been tested end-to-end due to local environment issues - mainnet testing is essential before deployment
- Requested by @blizzard25 
- Link to Devin run: https://app.devin.ai/sessions/1f84d8c9ccd6444f85e98749ed998ea6