### PR TITLE
Fix mainnet deployment: use EIP-1559 gas pricing for OpenZeppelin proxy deployments

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -26,7 +26,8 @@ module.exports = {
       url: MAINNET_RPC_URL,
       accounts: [PRIVATE_KEY],
       gas: 8000000,
-      gasPrice: 20000000000 // 20 gwei
+      maxFeePerGas: 25000000000, // 25 gwei
+      maxPriorityFeePerGas: 2000000000, // 2 gwei
     },
   },
   etherscan: {


### PR DESCRIPTION
_PR description is being written. Please check back in a minute._ 

Devin Session: https://app.devin.ai/sessions/1f84d8c9ccd6444f85e98749ed998ea6